### PR TITLE
Update tcp-server.md

### DIFF
--- a/_labs/tcp-server.md
+++ b/_labs/tcp-server.md
@@ -116,7 +116,7 @@ Options:
 
 - Return "error" (with the appropriate header) if an error occurs when processing a request, such as an invalid action.
 
-- If a client does not send enough data (e.g., the length is 10 but they only send 4 bytes), your server is allowed to block waiting for the remaining bytes of data.
+- If a client does not send enough data (e.g., the length is 10 but they only send 4 bytes), your server should block and wait for the remaining bytes of data. Otherwise, your server may not work when handling large amounts of data.
 
 - Properly shutdown server when an interrupt signal (`ctrl-c`) is sent to your process. If your server is in the middle of sending/receiving to a client, you can let that finish before stopping the server.
 


### PR DESCRIPTION
I read through the recommendation "If a client does not send enough data (e.g., the length is 10 but they only send 4 bytes), your server is allowed to block waiting for the remaining bytes of data."

However, upon implementing this lab, I realize that the above is required when sending large amounts of data, as the client will be unable to send it all at once, and the server will break if it can't handle the data separated into different packets. This caused me Segmentation faults on my client and a frozen server.

For this reason, I think the lab should say it's required, because this functionality is required to send messages up to 2^32, as allowed in the protocol.

My revision is: "If a client does not send enough data (e.g., the length is 10 but they only send 4 bytes), your server should block and wait for the remaining bytes of data. Otherwise, your server may not work when handling large amounts of data."